### PR TITLE
Use blog hero image for social cards

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -13,7 +13,7 @@ const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
 
 <html lang="en">
   <head>
-    <BaseHead title={title} description={description} />
+    <BaseHead title={title} description={description} image={heroImage} />
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css"


### PR DESCRIPTION
Pass the blog post heroImage to BaseHead component so that Open Graph and Twitter Card meta tags display the correct hero image when blog links are shared on social media platforms.

This ensures each blog post shows its unique cover image instead of the default fallback image.